### PR TITLE
TXARCH-1328 Add configurable app scheme support to allow us to set it to file

### DIFF
--- a/Photino.Blazor/PhotinoBlazorApp.cs
+++ b/Photino.Blazor/PhotinoBlazorApp.cs
@@ -1,7 +1,8 @@
-using Microsoft.Extensions.DependencyInjection;
-using PhotinoNET;
 using System;
 using System.IO;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using PhotinoNET;
 
 namespace Photino.Blazor
 {
@@ -16,6 +17,7 @@ namespace Photino.Blazor
         /// Gets configuration for the root components in the window.
         /// </summary>
         public BlazorWindowRootComponents RootComponents { get; private set; }
+        public PhotinoBlazorAppConfiguration Configuration { get; private set; }
 
         internal void Initialize(IServiceProvider services, RootComponentList rootComponents)
         {
@@ -23,6 +25,7 @@ namespace Photino.Blazor
             RootComponents = Services.GetService<BlazorWindowRootComponents>();
             MainWindow = Services.GetService<PhotinoWindow>();
             WindowManager = Services.GetService<PhotinoWebViewManager>();
+            Configuration = Services.GetService<IOptions<PhotinoBlazorAppConfiguration>>().Value;
 
             MainWindow
                 .SetTitle("Photino.Blazor App")
@@ -32,7 +35,7 @@ namespace Photino.Blazor
                 .SetLeft(450)
                 .SetTop(100);
 
-            MainWindow.RegisterCustomSchemeHandler(PhotinoWebViewManager.BlazorAppScheme, HandleWebRequest);
+            MainWindow.RegisterCustomSchemeHandler(Configuration.AppScheme, HandleWebRequest);
 
             foreach (var component in rootComponents)
             {

--- a/Photino.Blazor/PhotinoBlazorAppBuilder.cs
+++ b/Photino.Blazor/PhotinoBlazorAppBuilder.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.DependencyInjection;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Photino.Blazor
 {
@@ -14,13 +14,13 @@ namespace Photino.Blazor
             Services = new ServiceCollection();
         }
 
-        public static PhotinoBlazorAppBuilder CreateDefault(string[] args = default)
+        public static PhotinoBlazorAppBuilder CreateDefault(string[] args = default, string appScheme = null)
         {
             // We don't use the args for anything right now, but we want to accept them
             // here so that it shows up this way in the project templates.
             // var jsRuntime = DefaultWebAssemblyJSRuntime.Instance;
             var builder = new PhotinoBlazorAppBuilder();
-            builder.Services.AddBlazorDesktop();
+            builder.Services.AddBlazorDesktop(appScheme);
 
             // Right now we don't have conventions or behaviors that are specific to this method
             // however, making this the default for the template allows us to add things like that

--- a/Photino.Blazor/PhotinoBlazorAppConfiguration.cs
+++ b/Photino.Blazor/PhotinoBlazorAppConfiguration.cs
@@ -1,10 +1,19 @@
 using System;
+using System.Runtime.InteropServices;
 
 namespace Photino.Blazor
 {
     public class PhotinoBlazorAppConfiguration
     {
-        public Uri AppBaseUri { get; set; }
+        // On Windows, we can't use a custom scheme to host the initial HTML,
+        // because webview2 won't let you do top-level navigation to such a URL.
+        // On Linux/Mac, we must use a custom scheme, because their webviews
+        // don't have a way to intercept http:// scheme requests.
+        public string AppScheme { get; set; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "http"
+            : "app";
+
+        public Uri AppBaseUri { get { return new Uri($"{AppScheme}://localhost/"); } }
 
         public string HostPage { get; set; }
     }

--- a/Photino.Blazor/PhotinoBlazorAppConfiguration.cs
+++ b/Photino.Blazor/PhotinoBlazorAppConfiguration.cs
@@ -13,7 +13,7 @@ namespace Photino.Blazor
             ? "http"
             : "app";
 
-        public Uri AppBaseUri { get { return new Uri($"{AppScheme}://localhost/"); } }
+        public Uri AppBaseUri => new Uri($"{AppScheme}://localhost/");
 
         public string HostPage { get; set; }
     }

--- a/Photino.Blazor/PhotinoWebViewManager.cs
+++ b/Photino.Blazor/PhotinoWebViewManager.cs
@@ -1,18 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebView;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using PhotinoNET;
-using System;
-using System.IO;
-using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Channels;
-using System.Threading.Tasks;
 
 namespace Photino.Blazor
 {
@@ -20,22 +19,14 @@ namespace Photino.Blazor
     {
         private readonly PhotinoWindow _window;
         private readonly Channel<string> _channel;
-
-        // On Windows, we can't use a custom scheme to host the initial HTML,
-        // because webview2 won't let you do top-level navigation to such a URL.
-        // On Linux/Mac, we must use a custom scheme, because their webviews
-        // don't have a way to intercept http:// scheme requests.
-        public static readonly string BlazorAppScheme = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? "file"
-            : "app";
-
-        public static readonly string AppBaseUri = $"{BlazorAppScheme}://localhost/";
+        private readonly IOptions<PhotinoBlazorAppConfiguration> _config;
 
         public PhotinoWebViewManager(PhotinoWindow window, IServiceProvider provider, Dispatcher dispatcher,
             IFileProvider fileProvider, JSComponentConfigurationStore jsComponents, IOptions<PhotinoBlazorAppConfiguration> config)
             : base(provider, dispatcher, config.Value.AppBaseUri, fileProvider, jsComponents, config.Value.HostPage)
         {
             _window = window ?? throw new ArgumentNullException(nameof(window));
+            _config = config ?? throw new ArgumentNullException(nameof(config));
 
             // Create a scheduler that uses one threads.
             var sts = new Utils.SynchronousTaskScheduler();
@@ -48,7 +39,7 @@ namespace Photino.Blazor
                     // TODO: Fix this. Photino should ideally tell us the URL that the message comes from so we
                     // know whether to trust it. Currently it's hardcoded to trust messages from any source, including
                     // if the webview is somehow navigated to an external URL.
-                    var messageOriginUrl = new Uri(AppBaseUri);
+                    var messageOriginUrl = config.Value.AppBaseUri;
 
                     MessageReceived(messageOriginUrl, (string)message!);
                 }, message, CancellationToken.None, TaskCreationOptions.DenyChildAttach, sts);
@@ -69,7 +60,7 @@ namespace Photino.Blazor
             //Remove parameters before attempting to retrieve the file. For example: http://localhost/_content/Blazorise/button.js?v=1.0.7.0
             if (url.Contains('?')) url = url.Substring(0, url.IndexOf('?'));
 
-            if (url.StartsWith(AppBaseUri, StringComparison.Ordinal)
+            if (url.StartsWith(_config.Value.AppBaseUri.OriginalString, StringComparison.Ordinal)
                 && TryGetResponseContent(url, !hasFileExtension, out var statusCode, out var statusMessage,
                     out var content, out var headers))
             {

--- a/Photino.Blazor/ServiceCollectionExtensions.cs
+++ b/Photino.Blazor/ServiceCollectionExtensions.cs
@@ -5,19 +5,20 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
 using PhotinoNET;
 
 namespace Photino.Blazor
 {
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddBlazorDesktop(this IServiceCollection services)
+        public static IServiceCollection AddBlazorDesktop(this IServiceCollection services, string appScheme = null)
         {
             services
                 .AddOptions<PhotinoBlazorAppConfiguration>()
                 .Configure(opts =>
                 {
-                    opts.AppBaseUri = new Uri(PhotinoWebViewManager.AppBaseUri);
+                    opts.AppScheme = appScheme ?? opts.AppScheme;
                     opts.HostPage = "index.html";
                 });
 
@@ -25,7 +26,8 @@ namespace Photino.Blazor
                 .AddScoped(sp =>
                 {
                     var handler = sp.GetService<PhotinoHttpHandler>();
-                    return new HttpClient(handler) { BaseAddress = new Uri(PhotinoWebViewManager.AppBaseUri) };
+                    var opts = sp.GetService<IOptions<PhotinoBlazorAppConfiguration>>();
+                    return new HttpClient(handler) { BaseAddress = opts.Value.AppBaseUri };
                 })
                 .AddSingleton(sp =>
                 {


### PR DESCRIPTION
This change will allow us to pass in "file" as an argument to our photino app initialization which will enable us to use file scheme on the `src` attribute of our html elements and give us file system access to local directories other than our published `wwwroot`.

We still use photino's previous default values to keep their original support, but we can now override that value if one is provided.